### PR TITLE
添加播放源 CDN 覆盖设置

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/entity/CdnOverrideCatalog.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/entity/CdnOverrideCatalog.kt
@@ -108,7 +108,6 @@ object CdnOverrideCatalog {
             "upos-sz-mirror08c.bilivideo.com",
             "upos-sz-mirror08h.bilivideo.com",
             "upos-sz-mirroralibstar1.bilivideo.com",
-            "upos-sz-mirroraliov.bilivideo.com",
             "upos-sz-mirrorbd.bilivideo.com",
             "upos-sz-mirrorcf1ov.bilivideo.com",
             "upos-sz-mirrorcosbstar.bilivideo.com",
@@ -163,5 +162,6 @@ object CdnOverrideCatalog {
             .substringBefore("/")
             .substringBefore("?")
             .substringBefore("#")
+            .lowercase()
     }
 }

--- a/app/src/main/kotlin/dev/aaa1115910/bv/entity/CdnOverrideCatalog.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/entity/CdnOverrideCatalog.kt
@@ -1,0 +1,167 @@
+package dev.aaa1115910.bv.entity
+
+object CdnOverrideCatalog {
+    const val defaultRegion = "使用默认源"
+    const val customRegion = "手动输入"
+
+    val regionNodes = linkedMapOf(
+        "上海" to listOf(
+            "cn-sh-ct-01-01.bilivideo.com",
+            "cn-sh-ct-01-06.bilivideo.com",
+            "cn-sh-ct-01-13.bilivideo.com",
+            "cn-sh-ct-01-15.bilivideo.com",
+            "cn-sh-ct-01-23.bilivideo.com",
+            "cn-sh-ct-01-24.bilivideo.com",
+            "cn-sh-ct-01-35.bilivideo.com",
+            "cn-sh-ct-01-36.bilivideo.com",
+            "cn-sh-office-bcache-01.bilivideo.com"
+        ),
+        "北京" to listOf(
+            "cn-bj-cc-03-14.bilivideo.com",
+            "cn-bj-cc-03-17.bilivideo.com",
+            "cn-bj-fx-01-04.bilivideo.com",
+            "cn-bj-fx-01-05.bilivideo.com",
+            "cn-bj-se-01-05.bilivideo.com"
+        ),
+        "南京" to listOf(
+            "cn-jsnj-fx-02-05.bilivideo.com",
+            "cn-jsnj-fx-02-07.bilivideo.com",
+            "cn-jsnj-fx-02-10.bilivideo.com",
+            "cn-jsnj-gd-01-02.bilivideo.com"
+        ),
+        "天津" to listOf(
+            "cn-tj-cm-02-01.bilivideo.com",
+            "cn-tj-cm-02-02.bilivideo.com",
+            "cn-tj-cm-02-04.bilivideo.com",
+            "cn-tj-cm-02-05.bilivideo.com",
+            "cn-tj-cm-02-06.bilivideo.com",
+            "cn-tj-cm-02-07.bilivideo.com",
+            "cn-tj-cu-01-02.bilivideo.com",
+            "cn-tj-cu-01-03.bilivideo.com",
+            "cn-tj-cu-01-04.bilivideo.com",
+            "cn-tj-cu-01-05.bilivideo.com",
+            "cn-tj-cu-01-06.bilivideo.com",
+            "cn-tj-cu-01-07.bilivideo.com",
+            "cn-tj-cu-01-09.bilivideo.com",
+            "cn-tj-cu-01-10.bilivideo.com",
+            "cn-tj-cu-01-11.bilivideo.com",
+            "cn-tj-cu-01-12.bilivideo.com",
+            "cn-tj-cu-01-13.bilivideo.com"
+        ),
+        "广州" to listOf(
+            "cn-gdgz-cm-01-02.bilivideo.com",
+            "cn-gdgz-cm-01-10.bilivideo.com",
+            "cn-gdgz-fx-01-01.bilivideo.com",
+            "cn-gdgz-fx-01-02.bilivideo.com",
+            "cn-gdgz-fx-01-03.bilivideo.com",
+            "cn-gdgz-fx-01-04.bilivideo.com",
+            "cn-gdgz-fx-01-08.bilivideo.com",
+            "cn-gdgz-fx-01-10.bilivideo.com",
+            "cn-gdgz-gd-01-01.bilivideo.com"
+        ),
+        "成都" to listOf(
+            "cn-sccd-cm-03-02.bilivideo.com",
+            "cn-sccd-cm-03-05.bilivideo.com",
+            "cn-sccd-ct-01-02.bilivideo.com",
+            "cn-sccd-ct-01-08.bilivideo.com",
+            "cn-sccd-ct-01-10.bilivideo.com",
+            "cn-sccd-cu-01-02.bilivideo.com",
+            "cn-sccd-cu-01-03.bilivideo.com",
+            "cn-sccd-fx-01-01.bilivideo.com",
+            "cn-sccd-fx-01-06.bilivideo.com"
+        ),
+        "杭州" to listOf(
+            "cn-zjhz-cm-01-01.bilivideo.com",
+            "cn-zjhz-cm-01-04.bilivideo.com",
+            "cn-zjhz-cm-01-07.bilivideo.com",
+            "cn-zjhz-cm-01-12.bilivideo.com",
+            "cn-zjhz-cm-01-17.bilivideo.com",
+            "cn-zjhz-cu-01-01.bilivideo.com",
+            "cn-zjhz-cu-01-02.bilivideo.com",
+            "cn-zjhz-cu-01-05.bilivideo.com",
+            "cn-zjhz-cu-v-02.bilivideo.com"
+        ),
+        "武汉" to listOf(
+            "cn-hbwh-cm-01-01.bilivideo.com",
+            "cn-hbwh-cm-01-02.bilivideo.com",
+            "cn-hbwh-cm-01-04.bilivideo.com",
+            "cn-hbwh-cm-01-05.bilivideo.com",
+            "cn-hbwh-cm-01-06.bilivideo.com",
+            "cn-hbwh-cm-01-08.bilivideo.com",
+            "cn-hbwh-fx-01-01.bilivideo.com",
+            "cn-hbwh-fx-01-02.bilivideo.com"
+        ),
+        "沈阳" to listOf(
+            "cn-lnsy-cm-01-01.bilivideo.com",
+            "cn-lnsy-cm-01-03.bilivideo.com",
+            "cn-lnsy-cm-01-04.bilivideo.com",
+            "cn-lnsy-cm-01-05.bilivideo.com",
+            "cn-lnsy-cm-01-06.bilivideo.com",
+            "cn-lnsy-cu-01-03.bilivideo.com",
+            "cn-lnsy-cu-01-06.bilivideo.com"
+        ),
+        "深圳" to listOf(
+            "upos-sz-302kodo.bilivideo.com",
+            "upos-sz-dynqn.bilivideo.com",
+            "upos-sz-estgcos.bilivideo.com",
+            "upos-sz-estghw.bilivideo.com",
+            "upos-sz-mirror08c.bilivideo.com",
+            "upos-sz-mirror08h.bilivideo.com",
+            "upos-sz-mirroralibstar1.bilivideo.com",
+            "upos-sz-mirroraliov.bilivideo.com",
+            "upos-sz-mirrorbd.bilivideo.com",
+            "upos-sz-mirrorcf1ov.bilivideo.com",
+            "upos-sz-mirrorcosbstar.bilivideo.com",
+            "upos-sz-mirrorcosdisp.bilivideo.com",
+            "upos-sz-mirrorctos.bilivideo.com",
+            "upos-sz-mirrorhwdisp.bilivideo.com",
+            "upos-sz-originbstar.bilivideo.com",
+            "upos-sz-origincosgzhw.bilivideo.com",
+            "upos-sz-origincosv.bilivideo.com"
+        ),
+        "海外" to listOf(
+            "upos-hz-mirrorakam.akamaized.net",
+            "upos-sz-mirroraliov.bilivideo.com",
+            "upos-sz-mirrorcosov.bilivideo.com"
+        ),
+        "香港" to listOf(
+            "cn-hk-eq-01-01.bilivideo.com",
+            "cn-hk-eq-01-03.bilivideo.com",
+            "cn-hk-eq-01-09.bilivideo.com",
+            "cn-hk-eq-01-10.bilivideo.com",
+            "cn-hk-eq-01-12.bilivideo.com",
+            "cn-hk-eq-01-13.bilivideo.com",
+            "cn-hk-eq-01-14.bilivideo.com",
+            "cn-hk-eq-bcache-13.bilivideo.com"
+        )
+    )
+
+    val regions = listOf(defaultRegion) + regionNodes.keys + customRegion
+
+    fun nodesForRegion(region: String): List<String> = regionNodes[region].orEmpty()
+
+    fun regionForHost(host: String): String {
+        val normalizedHost = normalizeHost(host)
+        if (normalizedHost.isBlank()) return defaultRegion
+        return regionNodes.entries.firstOrNull { (_, nodes) -> normalizedHost in nodes }?.key
+            ?: customRegion
+    }
+
+    fun displayNameForHost(host: String): String {
+        val normalizedHost = normalizeHost(host)
+        return normalizedHost.ifBlank { defaultRegion }
+    }
+
+    fun normalizeHost(rawHost: String): String {
+        return rawHost
+            .trim()
+            .replace("\n", "")
+            .removePrefix("https://")
+            .removePrefix("http://")
+            .removePrefix("//")
+            .trim('/')
+            .substringBefore("/")
+            .substringBefore("?")
+            .substringBefore("#")
+    }
+}

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/NetworkSetting.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/NetworkSetting.kt
@@ -37,6 +37,7 @@ import dev.aaa1115910.bv.R
 import dev.aaa1115910.bv.activities.settings.SpeedTestActivity
 import dev.aaa1115910.bv.component.settings.SettingListItem
 import dev.aaa1115910.bv.component.settings.SettingSwitchListItem
+import dev.aaa1115910.bv.entity.CdnOverrideCatalog
 import dev.aaa1115910.bv.screen.settings.SettingsMenuNavItem
 import dev.aaa1115910.bv.ui.theme.BVTheme
 import dev.aaa1115910.bv.util.Prefs
@@ -52,8 +53,28 @@ fun NetworkSetting(
     var proxyHttpServer by remember { mutableStateOf(Prefs.proxyHttpServer) }
     var proxyGRPCServer by remember { mutableStateOf(Prefs.proxyGRPCServer) }
     var preferOfficialCdn by remember { mutableStateOf(Prefs.preferOfficialCdn) }
+    var cdnOverrideHost by remember { mutableStateOf(Prefs.cdnOverrideHost) }
+    var customCdnOverrideSelected by remember {
+        mutableStateOf(
+            Prefs.cdnOverrideHost.isNotBlank() &&
+                CdnOverrideCatalog.regionForHost(Prefs.cdnOverrideHost) == CdnOverrideCatalog.customRegion
+        )
+    }
     var showProxyHttpServerEditDialog by remember { mutableStateOf(false) }
     var showProxyGRPCServerEditDialog by remember { mutableStateOf(false) }
+    var showCdnOverrideRegionDialog by remember { mutableStateOf(false) }
+    var showCdnOverrideNodeDialog by remember { mutableStateOf(false) }
+    var showCdnOverrideCustomDialog by remember { mutableStateOf(false) }
+    val cdnOverrideRegion = if (customCdnOverrideSelected) {
+        CdnOverrideCatalog.customRegion
+    } else {
+        CdnOverrideCatalog.regionForHost(cdnOverrideHost)
+    }
+    val usingCustomCdnOverride = cdnOverrideRegion == CdnOverrideCatalog.customRegion
+    val usingPresetCdnOverride = cdnOverrideRegion !in listOf(
+        CdnOverrideCatalog.defaultRegion,
+        CdnOverrideCatalog.customRegion
+    )
 
     Box(
         modifier = modifier
@@ -108,15 +129,49 @@ fun NetworkSetting(
                 }
 
                 item {
-                    SettingSwitchListItem(
-                        title = stringResource(R.string.settings_network_prefer_official_cdn_title),
-                        supportText = stringResource(R.string.settings_network_prefer_official_cdn_text),
-                        checked = Prefs.preferOfficialCdn,
-                        onCheckedChange = { enable ->
-                            preferOfficialCdn = enable
-                            Prefs.preferOfficialCdn = enable
+                    Column {
+                        SettingSwitchListItem(
+                            title = stringResource(R.string.settings_network_prefer_official_cdn_title),
+                            supportText = stringResource(R.string.settings_network_prefer_official_cdn_text),
+                            checked = preferOfficialCdn,
+                            onCheckedChange = { enable ->
+                                preferOfficialCdn = enable
+                                Prefs.preferOfficialCdn = enable
+                            }
+                        )
+                        Column {
+                            SettingListItem(
+                                modifier = Modifier.padding(top = 12.dp),
+                                title = stringResource(R.string.settings_network_cdn_override_region_title),
+                                supportText = stringResource(R.string.settings_network_cdn_override_text) +
+                                    "\n" + stringResource(
+                                        R.string.settings_network_cdn_override_current,
+                                        cdnOverrideRegion
+                                    ),
+                                onClick = { showCdnOverrideRegionDialog = true }
+                            )
+                            AnimatedVisibility(visible = usingPresetCdnOverride) {
+                                SettingListItem(
+                                    modifier = Modifier.padding(top = 12.dp),
+                                    title = stringResource(R.string.settings_network_cdn_override_node_title),
+                                    supportText = CdnOverrideCatalog.displayNameForHost(cdnOverrideHost),
+                                    onClick = { showCdnOverrideNodeDialog = true }
+                                )
+                            }
+                            AnimatedVisibility(visible = usingCustomCdnOverride) {
+                                SettingListItem(
+                                    modifier = Modifier.padding(top = 12.dp),
+                                    title = stringResource(R.string.settings_network_cdn_override_custom_title),
+                                    supportText = if (cdnOverrideHost.isBlank()) {
+                                        stringResource(R.string.settings_network_proxy_server_content_empty)
+                                    } else {
+                                        cdnOverrideHost
+                                    },
+                                    onClick = { showCdnOverrideCustomDialog = true }
+                                )
+                            }
                         }
-                    )
+                    }
                 }
 
                 item {
@@ -160,6 +215,105 @@ fun NetworkSetting(
             }
         }
     )
+
+    if (showCdnOverrideRegionDialog) {
+        OptionDialog(
+            options = CdnOverrideCatalog.regions.toTypedArray(),
+            selectedOption = cdnOverrideRegion,
+            onDismiss = { showCdnOverrideRegionDialog = false },
+            onSelect = { region ->
+                when (region) {
+                    CdnOverrideCatalog.defaultRegion -> {
+                        customCdnOverrideSelected = false
+                        cdnOverrideHost = ""
+                        Prefs.cdnOverrideHost = ""
+                    }
+
+                    CdnOverrideCatalog.customRegion -> {
+                        showCdnOverrideCustomDialog = true
+                    }
+
+                    else -> {
+                        val firstNode = CdnOverrideCatalog.nodesForRegion(region).firstOrNull().orEmpty()
+                        customCdnOverrideSelected = false
+                        cdnOverrideHost = firstNode
+                        Prefs.cdnOverrideHost = firstNode
+                    }
+                }
+                showCdnOverrideRegionDialog = false
+            },
+            getDisplayName = { it }
+        )
+    }
+
+    if (showCdnOverrideNodeDialog && CdnOverrideCatalog.nodesForRegion(cdnOverrideRegion).isNotEmpty()) {
+        val nodes = CdnOverrideCatalog.nodesForRegion(cdnOverrideRegion)
+        OptionDialog(
+            options = nodes.toTypedArray(),
+            selectedOption = cdnOverrideHost.takeIf { it in nodes } ?: nodes.first(),
+            onDismiss = { showCdnOverrideNodeDialog = false },
+            onSelect = {
+                cdnOverrideHost = it
+                Prefs.cdnOverrideHost = it
+                showCdnOverrideNodeDialog = false
+            },
+            getDisplayName = { it }
+        )
+    }
+
+    CdnOverrideHostEditDialog(
+        show = showCdnOverrideCustomDialog,
+        onHideDialog = { showCdnOverrideCustomDialog = false },
+        cdnHost = if (customCdnOverrideSelected) cdnOverrideHost else "",
+        onCdnHostChange = {
+            val normalizedHost = CdnOverrideCatalog.normalizeHost(it)
+            customCdnOverrideSelected = normalizedHost.isNotBlank()
+            cdnOverrideHost = normalizedHost
+            Prefs.cdnOverrideHost = normalizedHost
+        }
+    )
+}
+
+@Composable
+fun CdnOverrideHostEditDialog(
+    modifier: Modifier = Modifier,
+    show: Boolean,
+    onHideDialog: () -> Unit,
+    cdnHost: String,
+    onCdnHostChange: (String) -> Unit
+) {
+    var cdnHostString by remember(show) { mutableStateOf(cdnHost) }
+
+    if (show) {
+        AlertDialog(
+            modifier = modifier,
+            title = { Text(text = stringResource(R.string.settings_network_cdn_override_custom_title)) },
+            text = {
+                OutlinedTextField(
+                    value = cdnHostString,
+                    onValueChange = { cdnHostString = it },
+                    singleLine = true,
+                    maxLines = 1,
+                    shape = MaterialTheme.shapes.medium,
+                    placeholder = { Text(text = stringResource(R.string.settings_network_cdn_override_input_label)) }
+                )
+            },
+            onDismissRequest = onHideDialog,
+            confirmButton = {
+                Button(onClick = {
+                    onCdnHostChange(CdnOverrideCatalog.normalizeHost(cdnHostString))
+                    onHideDialog()
+                }) {
+                    Text(text = stringResource(id = R.string.common_confirm))
+                }
+            },
+            dismissButton = {
+                OutlinedButton(onClick = onHideDialog) {
+                    Text(text = stringResource(id = R.string.common_cancel))
+                }
+            }
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/NetworkSetting.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/NetworkSetting.kt
@@ -301,7 +301,9 @@ fun CdnOverrideHostEditDialog(
             onDismissRequest = onHideDialog,
             confirmButton = {
                 Button(onClick = {
-                    onCdnHostChange(CdnOverrideCatalog.normalizeHost(cdnHostString))
+                    CdnOverrideCatalog.normalizeHost(cdnHostString)
+                        .takeIf { it.isNotBlank() }
+                        ?.let(onCdnHostChange)
                     onHideDialog()
                 }) {
                     Text(text = stringResource(id = R.string.common_confirm))

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/OptionDialog.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/OptionDialog.kt
@@ -25,7 +25,7 @@ import dev.aaa1115910.bv.component.settings.SettingsMenuSelectItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun <T : Enum<T>> OptionDialog(
+fun <T> OptionDialog(
     modifier: Modifier = Modifier,
     options: Array<T>,
     selectedOption: T,

--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
@@ -100,6 +100,7 @@ object Prefs {
     var proxyHttpServer by pref(PrefKeys.prefProxyHttpServerKey, "")
     var proxyGRPCServer by pref(PrefKeys.prefProxyGRPCServerKey, "")
     var preferOfficialCdn by pref(PrefKeys.prefPreferOfficialCdn, false)
+    var cdnOverrideHost by pref(PrefKeys.prefCdnOverrideHost, "")
 
     // =========================================================================
     // 播放器 - 视频
@@ -343,6 +344,7 @@ private object PrefKeys {
     val prefProxyHttpServerKey = stringPreferencesKey("proxy_http_server")
     val prefProxyGRPCServerKey = stringPreferencesKey("proxy_grpc_server")
     val prefPreferOfficialCdn = booleanPreferencesKey("prefer_official_cdn")
+    val prefCdnOverrideHost = stringPreferencesKey("cdn_override_host")
 
     // 播放器 - 视频
     val prefDefaultQualityKey = intPreferencesKey("dq")

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -27,6 +27,7 @@ import dev.aaa1115910.bv.BVApp
 import dev.aaa1115910.bv.R
 import dev.aaa1115910.bv.component.controllers.DanmakuType
 import dev.aaa1115910.bv.entity.Audio
+import dev.aaa1115910.bv.entity.CdnOverrideCatalog
 import dev.aaa1115910.bv.entity.PlayerType
 import dev.aaa1115910.bv.entity.Resolution
 import dev.aaa1115910.bv.entity.VideoAspectRatio
@@ -893,6 +894,11 @@ class VideoPlayerV3ViewModel(
             audioUrl = if (audioUrls.isNotEmpty()) selectOfficialCdnUrl(audioUrls) else null
         }
 
+        if (Prefs.preferOfficialCdn) {
+            videoUrl = videoUrl.replaceMediaUrlHostWithCdnOverride()
+            audioUrl = audioUrl?.replaceMediaUrlHostWithCdnOverride()
+        }
+
         logger.fInfo { "Audio encoding：${(Audio.fromCode(audioItem?.codecId ?: 0))}" }
         logger.info { "Video url: $videoUrl" }
         logger.info { "Audio url: $audioUrl" }
@@ -1375,6 +1381,32 @@ class VideoPlayerV3ViewModel(
             .authority("upos-sz-mirrorali.bilivideo.com")
             .build()
             .toString()
+    }
+
+    private fun String.replaceMediaUrlHostWithCdnOverride(): String {
+        val replacementHost = CdnOverrideCatalog.normalizeHost(Prefs.cdnOverrideHost)
+        if (replacementHost.isBlank()) return this
+
+        val parsedUri = Uri.parse(this)
+        val originalHost = parsedUri.host ?: return this
+        if (!originalHost.isReplaceableMediaHost()) return this
+
+        return parsedUri
+            .buildUpon()
+            .authority(replacementHost)
+            .build()
+            .toString()
+    }
+
+    private fun String.isReplaceableMediaHost(): Boolean {
+        val host = lowercase()
+        val ignoreHostRegex = Regex("^(?:bvc|data|pbp|api\\w*)\\.")
+        if (ignoreHostRegex.containsMatchIn(host)) return false
+
+        return host.contains("bilivideo.")
+            || host.contains("acgvideo.")
+            || host.contains("edge.mountaintoys.cn")
+            || host.contains("akamaized.net")
     }
 
     private sealed interface NextPlayTarget {

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -892,11 +892,11 @@ class VideoPlayerV3ViewModel(
             // 如果未通过网络代理获得播放地址，才判断是否应该替换为官方 cdn
             videoUrl = selectOfficialCdnUrl(videoUrls.filterNotNull())
             audioUrl = if (audioUrls.isNotEmpty()) selectOfficialCdnUrl(audioUrls) else null
-        }
 
-        if (Prefs.preferOfficialCdn) {
-            videoUrl = videoUrl.replaceMediaUrlHostWithCdnOverride()
-            audioUrl = audioUrl?.replaceMediaUrlHostWithCdnOverride()
+            if (Prefs.preferOfficialCdn) {
+                videoUrl = videoUrl.replaceMediaUrlHostWithCdnOverride()
+                audioUrl = audioUrl?.replaceMediaUrlHostWithCdnOverride()
+            }
         }
 
         logger.fInfo { "Audio encoding：${(Audio.fromCode(audioItem?.codecId ?: 0))}" }
@@ -1402,6 +1402,7 @@ class VideoPlayerV3ViewModel(
         val host = lowercase()
         val ignoreHostRegex = Regex("^(?:bvc|data|pbp|api\\w*)\\.")
         if (ignoreHostRegex.containsMatchIn(host)) return false
+        if (host.contains(".mcdn.bilivideo.")) return false
 
         return host.contains("bilivideo.")
             || host.contains("acgvideo.")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -249,6 +249,13 @@
     <string name="settings_media_software_video_renderer_text">使用软件解码器播放硬解不兼容的视频</string>
     <string name="settings_network_enable_proxy_text">使用自定义代理服务器获取部分视频播放地址</string>
     <string name="settings_network_enable_proxy_title">启用代理</string>
+    <string name="settings_network_cdn_override_custom_title">自定义播放源</string>
+    <string name="settings_network_cdn_override_current">当前：%1$s</string>
+    <string name="settings_network_cdn_override_default">使用默认源</string>
+    <string name="settings_network_cdn_override_input_label">CDN 节点域名或 URL</string>
+    <string name="settings_network_cdn_override_node_title">播放源节点</string>
+    <string name="settings_network_cdn_override_region_title">播放源地区覆盖</string>
+    <string name="settings_network_cdn_override_text">启用上方“P(M)CDN 快走开”后生效，将播放地址切换到指定官方 CDN 地区或自定义节点</string>
     <string name="settings_network_prefer_official_cdn_text">优先使用获取到的官方 CDN</string>
     <string name="settings_network_prefer_official_cdn_title">P(M)CDN 快走开</string>
     <string name="settings_network_proxy_grpc_server_title">gRPC 接口代理服务器</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -251,7 +251,6 @@
     <string name="settings_network_enable_proxy_title">启用代理</string>
     <string name="settings_network_cdn_override_custom_title">自定义播放源</string>
     <string name="settings_network_cdn_override_current">当前：%1$s</string>
-    <string name="settings_network_cdn_override_default">使用默认源</string>
     <string name="settings_network_cdn_override_input_label">CDN 节点域名或 URL</string>
     <string name="settings_network_cdn_override_node_title">播放源节点</string>
     <string name="settings_network_cdn_override_region_title">播放源地区覆盖</string>


### PR DESCRIPTION
## 背景

最近阿B的海外 CDN 越来越吃屎了。桌面端我一直在用 [ccb](https://github.com/Kanda-Akihito-Kun/ccb) 这个浏览器插件手动切 CDN，整挺好，于是想着给 BV 也整一个。

这次主要是给网络设置页加了一个“播放源地区覆盖”，可以手动指定播放源地区或 CDN 节点。实现参考了 ccb 公开的 CDN 节点列表和 host 替换/忽略规则，但不依赖 ccb 的接口或服务，所有选择和 URL 替换都在 BV 客户端本地完成。

## Changes

- 网络设置页新增“播放源地区覆盖”
- 支持从预设地区里选择 CDN 节点
- 支持手动输入自定义 CDN 节点域名
- 播放地址解析后，对可替换的媒体 URL host 进行覆盖
- 目前 CDN 覆盖跟随“P(M)CDN 快走开”开关生效
- CDN 节点列表和 host 规范化逻辑单独拆了出来，避免设置页变成一碗面

## 说明

目前 CDN 覆盖需要开启“P(M)CDN 快走开”后才会生效。主要是因为我的需求是先把 PCDN 请出去，然后再指定官方 CDN 节点，这样实现范围也比较小。

节点列表目前是客户端内置的静态列表。好处是不依赖已经不可用的 ccb API，也不用额外请求外部服务；坏处是如果 B 站后续调整 CDN 节点，可能需要同步更新一下列表。

如果维护者觉得这个功能应该独立于“P(M)CDN 快走开”生效，也可以继续改。
另外，由于网络测试页目前是 WebView 内嵌的 B 站网页，这次没有碰这部分逻辑，也没有调整当前的文字提示。用户可能自然而然的以为这里可以拿来测试 CDN 覆盖后的效果，可能会让用户产生一点误解；这个如果需要的话可以后续单独处理。

## 测试

我在本地电视端构建并测试过：

- Web API 播放地址：CDN 覆盖正常生效
- App API 播放地址：CDN 覆盖正常生效
- 默认源、预设节点、自定义节点之间切换正常
- 选择“手动输入”但不填写地址时，会回到默认源，不进行 host 覆盖

## 当前 UI
<img width="2298" height="1730" alt="image" src="https://github.com/user-attachments/assets/da4352e5-a44a-41d7-bfdf-34f99db85beb" />
<img width="2298" height="1730" alt="image" src="https://github.com/user-attachments/assets/9ff8e3cc-44dd-484e-8497-a498acc1a579" />

