### PR TITLE
增加自动帧率匹配开关

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/AudioVideoSetting.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/AudioVideoSetting.kt
@@ -55,6 +55,7 @@ fun AudioVideoSetting(
 
     var enableFfmpegAudioRenderer by remember { mutableStateOf(Prefs.enableFfmpegAudioRenderer) }
     var enableSoftwareVideoRenderer by remember { mutableStateOf(Prefs.enableSoftwareVideoDecoder) }
+    var enableFrameRateMatching by remember { mutableStateOf(Prefs.enableFrameRateMatching) }
 
     Column(
         modifier = modifier
@@ -98,6 +99,15 @@ fun AudioVideoSetting(
             title = "自定义播放快捷键",
             supportText = "当前：${playerCustomShortcuts.size} 个绑定",
             onClick = { showPlayerCustomShortcutsDialog = true }
+        )
+        SettingSwitchListItem(
+            title = "自动帧率匹配",
+            supportText = "使用 Media3 默认帧率匹配策略",
+            checked = enableFrameRateMatching,
+            onCheckedChange = {
+                enableFrameRateMatching = it
+                Prefs.enableFrameRateMatching = it
+            }
         )
         SettingSwitchListItem(
             title = stringResource(R.string.settings_media_software_video_renderer_title),
@@ -209,4 +219,3 @@ enum class ActionAfterPlayItems (val code: Int, private val displayName: String)
         return displayName
     }
 }
-

--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
@@ -124,6 +124,7 @@ object Prefs {
         restore = { PlayerType.entries.getOrElse(it) { PlayerType.Media3 } }
     )
     var enableSoftwareVideoDecoder by pref(PrefKeys.prefEnableSoftwareVideoDecoder, false)
+    var enableFrameRateMatching by pref(PrefKeys.prefEnableFrameRateMatching, true)
     var actionAfterPlay by pref(
         PrefKeys.prefActionAfterPlayKey,
         ActionAfterPlayItems.PlayNext,
@@ -349,6 +350,7 @@ private object PrefKeys {
     val prefDefaultVideoCodecKey = intPreferencesKey("dvc")
     val prefPlayerTypeKey = intPreferencesKey("pt")
     val prefEnableSoftwareVideoDecoder = booleanPreferencesKey("enable_software_video_decoder")
+    val prefEnableFrameRateMatching = booleanPreferencesKey("enable_frame_rate_matching")
     val prefActionAfterPlayKey = intPreferencesKey("action_after_play")
 
     // 播放器 - 音频

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -265,7 +265,8 @@ class VideoPlayerV3ViewModel(
                 ApiType.App -> null
             },
             enableFfmpegAudioRenderer = Prefs.enableFfmpegAudioRenderer,
-            enableSoftwareVideoDecoder = Prefs.enableSoftwareVideoDecoder
+            enableSoftwareVideoDecoder = Prefs.enableSoftwareVideoDecoder,
+            enableFrameRateMatching = Prefs.enableFrameRateMatching
         )
 
         val newVideoPlayer = when (Prefs.playerType) {

--- a/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/VideoPlayerOptions.kt
+++ b/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/VideoPlayerOptions.kt
@@ -4,5 +4,6 @@ data class VideoPlayerOptions(
     val userAgent: String? = null,
     val referer: String? = null,
     val enableFfmpegAudioRenderer: Boolean,
-    val enableSoftwareVideoDecoder: Boolean
+    val enableSoftwareVideoDecoder: Boolean,
+    val enableFrameRateMatching: Boolean = true
 )

--- a/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
+++ b/bv-player/src/main/kotlin/dev/aaa1115910/bv/player/impl/exo/ExoMediaPlayer.kt
@@ -74,6 +74,11 @@ class ExoMediaPlayer(
             .setRenderersFactory(renderersFactory)
             .setSeekForwardIncrementMs(1000 * 10)
             .setSeekBackIncrementMs(1000 * 5)
+            .apply {
+                if (!options.enableFrameRateMatching) {
+                    setVideoChangeFrameRateStrategy(C.VIDEO_CHANGE_FRAME_RATE_STRATEGY_OFF)
+                }
+            }
             .build()
 
         initListener()


### PR DESCRIPTION
# 问题

当前项目使用安卓的media3播放器，它默认会启动无缝帧率切换，例如大多数电视的30/60帧的切换都可以无缝完成。

而B站的视频，绝大多数都是30帧，这就导致在播放这些视频时，电视的刷新率会切换到30，对于视频播放来说，这并没有什么问题。但是对于弹幕来说，就会明显变得卡顿，尤其是在大尺寸电视上，卡顿感会更加明显，有时甚至难以看清弹幕。

# 修复

实际上对于30帧的视频，只要电视的刷新率是30帧的整数倍，播放都不会有任何问题。而绝大多数电视的默认帧率是60帧，因此只要让电视工作在60帧下，不仅视频可以正常播放，弹幕也会更加流畅。

当前PR在播放设置中增加了一个“自动帧率匹配”的开关，默认为开启状态。如果希望让电视始终保持默认刷新率，就可以关闭此开关。

# 测试

打开FPS显示开关，即可查看当前画面的帧率。

- 当”自动帧率匹配“为开时，画面帧率会随着视频帧率变化，当变为30帧时，弹幕轨迹卡顿。
- 当”自动帧率匹配“为关时，画面帧率会始终维持在默认帧率，弹幕轨迹流畅。