### PR TITLE
[codex] add default subtitle settings

### DIFF
--- a/app/src/main/kotlin/dev/aaa1115910/bv/entity/SubtitleLanguagePreference.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/entity/SubtitleLanguagePreference.kt
@@ -1,0 +1,52 @@
+package dev.aaa1115910.bv.entity
+
+import dev.aaa1115910.biliapi.entity.video.Subtitle
+
+enum class SubtitleLanguagePreference(
+    val code: String,
+    private val displayName: String
+) {
+    FirstAvailable("first", "首个可用字幕"),
+    SimplifiedChinese("zh-hans", "简体中文"),
+    TraditionalChinese("zh-hant", "繁体中文"),
+    English("en", "English"),
+    Japanese("ja", "日本語"),
+    Korean("ko", "한국어");
+
+    fun getDisplayName() = displayName
+
+    fun select(subtitles: List<Subtitle>): Subtitle? {
+        val availableSubtitles = subtitles.filter { it.id != -1L }
+        if (this == FirstAvailable) return availableSubtitles.firstOrNull()
+
+        return availableSubtitles.firstOrNull { matches(it.lang) }
+    }
+
+    internal fun matches(languageCode: String): Boolean {
+        val normalizedCode = languageCode.trim().lowercase().removePrefix("ai-")
+        return when (this) {
+            FirstAvailable -> true
+            SimplifiedChinese -> normalizedCode == "zh" ||
+                normalizedCode.matches("zh-hans") ||
+                normalizedCode.matches("zh-cn") ||
+                normalizedCode.matches("zh-sg")
+            TraditionalChinese -> normalizedCode.matches("zh-hant") ||
+                normalizedCode.matches("zh-tw") ||
+                normalizedCode.matches("zh-hk") ||
+                normalizedCode.matches("zh-mo")
+            English -> normalizedCode.matches("en")
+            Japanese -> normalizedCode.matches("ja")
+            Korean -> normalizedCode.matches("ko")
+        }
+    }
+
+    companion object {
+        fun fromCode(code: String): SubtitleLanguagePreference {
+            return entries.find { it.code == code } ?: FirstAvailable
+        }
+    }
+}
+
+private fun String.matches(languageCode: String): Boolean {
+    return this == languageCode || startsWith("$languageCode-")
+}

--- a/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/AudioVideoSetting.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/screen/settings/content/AudioVideoSetting.kt
@@ -28,6 +28,7 @@ import dev.aaa1115910.bv.component.settings.SettingSwitchListItem
 import dev.aaa1115910.bv.entity.Audio
 import dev.aaa1115910.bv.entity.PlayerCustomShortcutsStore
 import dev.aaa1115910.bv.entity.Resolution
+import dev.aaa1115910.bv.entity.SubtitleLanguagePreference
 import dev.aaa1115910.bv.entity.VideoCodec
 import dev.aaa1115910.bv.screen.settings.SettingsMenuNavItem
 import dev.aaa1115910.bv.util.Prefs
@@ -43,6 +44,7 @@ fun AudioVideoSetting(
     var showAudioCodecDialog by remember { mutableStateOf(false) }
     var showVideoCodecDialog by remember { mutableStateOf(false) }
     var showPlaySpeedDialog by remember { mutableStateOf(false) }
+    var showSubtitleLanguageDialog by remember { mutableStateOf(false) }
     var showActionAfterPlayDialog by remember { mutableStateOf(false) }
     var showPlayerCustomShortcutsDialog by remember { mutableStateOf(false) }
 
@@ -50,11 +52,13 @@ fun AudioVideoSetting(
     var selectedVideoCodec by remember { mutableStateOf(Prefs.defaultVideoCodec) }
     var selectedAudioCodec by remember { mutableStateOf(Prefs.defaultAudio) }
     var selectedPlaySpeed by remember { mutableStateOf(Prefs.defaultPlaySpeed) }
+    var selectedSubtitleLanguage by remember { mutableStateOf(Prefs.defaultSubtitleLanguage) }
     var selectedActionAfterPlay by remember { mutableStateOf(Prefs.actionAfterPlay) }
     var playerCustomShortcuts by remember { mutableStateOf(PlayerCustomShortcutsStore.get()) }
 
     var enableFfmpegAudioRenderer by remember { mutableStateOf(Prefs.enableFfmpegAudioRenderer) }
     var enableSoftwareVideoRenderer by remember { mutableStateOf(Prefs.enableSoftwareVideoDecoder) }
+    var autoLoadSubtitle by remember { mutableStateOf(Prefs.autoLoadSubtitle) }
 
     Column(
         modifier = modifier
@@ -88,6 +92,20 @@ fun AudioVideoSetting(
             title = "默认播放速度",
             supportText = "当前：${selectedPlaySpeed.getDisplayName(context)}",
             onClick = { showPlaySpeedDialog = true }
+        )
+        SettingSwitchListItem(
+            title = "默认加载字幕",
+            supportText = "进入播放器时自动加载字幕",
+            checked = autoLoadSubtitle,
+            onCheckedChange = {
+                autoLoadSubtitle = it
+                Prefs.autoLoadSubtitle = it
+            }
+        )
+        SettingListItem(
+            title = "默认字幕语言",
+            supportText = "当前：${selectedSubtitleLanguage.getDisplayName()}；不可用时关闭字幕",
+            onClick = { showSubtitleLanguageDialog = true }
         )
         SettingListItem(
             title = "播放结束动作",
@@ -184,6 +202,19 @@ fun AudioVideoSetting(
         )
     }
 
+    if (showSubtitleLanguageDialog) {
+        OptionDialog(
+            options = SubtitleLanguagePreference.entries.toTypedArray(),
+            selectedOption = selectedSubtitleLanguage,
+            onDismiss = { showSubtitleLanguageDialog = false },
+            onSelect = {
+                Prefs.defaultSubtitleLanguage = it
+                selectedSubtitleLanguage = it
+            },
+            getDisplayName = { it.getDisplayName() }
+        )
+    }
+
     if (showPlayerCustomShortcutsDialog) {
         PlayerCustomShortcutsDialog(
             onDismiss = { showPlayerCustomShortcutsDialog = false },
@@ -209,4 +240,3 @@ enum class ActionAfterPlayItems (val code: Int, private val displayName: String)
         return displayName
     }
 }
-

--- a/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/util/Prefs.kt
@@ -20,6 +20,7 @@ import dev.aaa1115910.bv.component.controllers.playermenu.PlaySpeedItem
 import dev.aaa1115910.bv.entity.Audio
 import dev.aaa1115910.bv.entity.PlayerType
 import dev.aaa1115910.bv.entity.Resolution
+import dev.aaa1115910.bv.entity.SubtitleLanguagePreference
 import dev.aaa1115910.bv.entity.VideoCodec
 import dev.aaa1115910.bv.screen.main.LeftNaviItem
 import dev.aaa1115910.bv.screen.settings.content.ActionAfterPlayItems
@@ -172,6 +173,13 @@ object Prefs {
     // 播放器 - 字幕
     // =========================================================================
 
+    var autoLoadSubtitle by pref(PrefKeys.prefAutoLoadSubtitleKey, false)
+    var defaultSubtitleLanguage by pref(
+        PrefKeys.prefDefaultSubtitleLanguageKey,
+        SubtitleLanguagePreference.FirstAvailable,
+        save = { it.code },
+        restore = { SubtitleLanguagePreference.fromCode(it) }
+    )
     var defaultSubtitleFontSize by pref(
         PrefKeys.prefDefaultSubtitleFontSizeKey,
         24.sp,
@@ -364,6 +372,8 @@ private object PrefKeys {
     val prefDefaultDanmakuMask = booleanPreferencesKey("prefer_enable_webmark")
 
     // 播放器 - 字幕
+    val prefAutoLoadSubtitleKey = booleanPreferencesKey("auto_load_subtitle")
+    val prefDefaultSubtitleLanguageKey = stringPreferencesKey("default_subtitle_language")
     val prefDefaultSubtitleFontSizeKey = intPreferencesKey("dsfs")
     val prefDefaultSubtitleBackgroundOpacityKey = floatPreferencesKey("dsbo")
     val prefDefaultSubtitleBottomPaddingKey = intPreferencesKey("dsbp")

--- a/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
+++ b/app/src/main/kotlin/dev/aaa1115910/bv/viewmodel/player/VideoPlayerV3ViewModel.kt
@@ -623,10 +623,11 @@ class VideoPlayerV3ViewModel(
 
                 launch {
                     updateSubtitle()
-                    val lastPlayEnabledSubtitle = _uiState.value.subtitleId != -1L
-                    if (lastPlayEnabledSubtitle) {
-                        logger.info { "Subtitle is enabled, auto-enabling first subtitle..." }
-                        enableFirstSubtitle()
+                    val shouldEnableSubtitle = Prefs.autoLoadSubtitle ||
+                        _uiState.value.subtitleId != -1L
+                    if (shouldEnableSubtitle) {
+                        logger.info { "Auto-enabling preferred subtitle..." }
+                        enablePreferredSubtitle()
                     }
                 }
                 launch { loadDanmaku(cid) }
@@ -970,18 +971,18 @@ class VideoPlayerV3ViewModel(
         }
     }
 
-    private fun enableFirstSubtitle() {
-        runCatching {
-            logger.info { "Load first subtitle" }
-            logger.info { "availableSubtitle: ${_uiState.value.subtitleList.toList()}" }
-            loadSubtitle(
-                _uiState.value.subtitleList
-                    .firstOrNull { it.id != -1L }?.id
-                    ?: throw IllegalStateException("No available subtitle")
-            )
-        }.onFailure {
-            logger.error { "Load first subtitle failed: ${it.stackTraceToString()}" }
+    private fun enablePreferredSubtitle() {
+        logger.info { "Load preferred subtitle: ${Prefs.defaultSubtitleLanguage.code}" }
+        logger.info { "availableSubtitle: ${_uiState.value.subtitleList.toList()}" }
+
+        val selectedSubtitle = Prefs.defaultSubtitleLanguage.select(_uiState.value.subtitleList)
+        if (selectedSubtitle == null) {
+            logger.info { "Preferred subtitle is unavailable, disabling subtitles" }
+            loadSubtitle(-1L)
+            return
         }
+
+        loadSubtitle(selectedSubtitle.id)
     }
 
     private fun syncProgress(

--- a/app/src/test/kotlin/dev/aaa1115910/bv/entity/SubtitleLanguagePreferenceTest.kt
+++ b/app/src/test/kotlin/dev/aaa1115910/bv/entity/SubtitleLanguagePreferenceTest.kt
@@ -1,0 +1,78 @@
+package dev.aaa1115910.bv.entity
+
+import dev.aaa1115910.biliapi.entity.video.Subtitle
+import dev.aaa1115910.biliapi.entity.video.SubtitleAiStatus
+import dev.aaa1115910.biliapi.entity.video.SubtitleAiType
+import dev.aaa1115910.biliapi.entity.video.SubtitleType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SubtitleLanguagePreferenceTest {
+    @Test
+    fun `selects preferred language instead of list order`() {
+        val subtitles = listOf(
+            subtitle(1, "en-US"),
+            subtitle(2, "zh-Hans")
+        )
+
+        val selected = SubtitleLanguagePreference.SimplifiedChinese.select(subtitles)
+
+        assertEquals(2L, selected?.id)
+    }
+
+    @Test
+    fun `recognizes ai subtitle language codes`() {
+        val subtitles = listOf(
+            subtitle(1, "ai-en"),
+            subtitle(2, "ai-zh")
+        )
+
+        assertEquals(
+            2L,
+            SubtitleLanguagePreference.SimplifiedChinese.select(subtitles)?.id
+        )
+    }
+
+    @Test
+    fun `keeps simplified and traditional ai subtitles distinct`() {
+        val subtitles = listOf(subtitle(1, "ai-zh-Hant"))
+
+        assertNull(SubtitleLanguagePreference.SimplifiedChinese.select(subtitles))
+        assertEquals(
+            1L,
+            SubtitleLanguagePreference.TraditionalChinese.select(subtitles)?.id
+        )
+    }
+
+    @Test
+    fun `returns no subtitle when preferred language is unavailable`() {
+        val subtitles = listOf(
+            subtitle(-1, "off"),
+            subtitle(1, "en-US"),
+            subtitle(2, "ja-JP")
+        )
+
+        val selected = SubtitleLanguagePreference.TraditionalChinese.select(subtitles)
+
+        assertNull(selected)
+    }
+
+    @Test
+    fun `restores unknown stored value safely`() {
+        assertEquals(
+            SubtitleLanguagePreference.FirstAvailable,
+            SubtitleLanguagePreference.fromCode("unknown")
+        )
+    }
+
+    private fun subtitle(id: Long, languageCode: String) = Subtitle(
+        id = id,
+        lang = languageCode,
+        langDoc = languageCode,
+        url = "https://example.com/$id",
+        type = SubtitleType.CC,
+        aiType = SubtitleAiType.Normal,
+        aiStatus = SubtitleAiStatus.None
+    )
+}


### PR DESCRIPTION
## Summary

- add a "load subtitles by default" setting
- allow selecting the first available subtitle track or Simplified Chinese, Traditional Chinese, English, Japanese, or Korean
- strictly match the selected language and disable subtitles when that language is unavailable, without falling back
- persist the settings with DataStore and preserve subtitle enabled state during continuous playback
- add unit coverage for subtitle language matching

## Why

Subtitle selection was controlled only from the player and could not be configured as a default preference. This gives users predictable subtitle behavior across playback sessions while avoiding unexpected fallback languages.

## Validation

- `git diff --check feature-base..HEAD`
- standalone Kotlin compile and behavior verification on JDK 17: `SubtitleLanguagePreference verification passed`
- full Android build not run because the local environment does not have the Android SDK installed
